### PR TITLE
Fix destination reordering and moving bugs

### DIFF
--- a/lib/destination-service.ts
+++ b/lib/destination-service.ts
@@ -397,7 +397,11 @@ export async function reorderDestinationsWithAuth(
       throw new Error('Insufficient permissions to reorder destinations');
     }
 
-    await reorderDestinations(destinations);
+    await reorderDestinations(
+      destinations[0].tripId,
+      destinations[0].day,
+      destinations.map(d => d.id)
+    );
     
     // Log activity
     await logTripActivity(
@@ -437,7 +441,8 @@ export async function moveDestinationToDayWithAuth(
       throw new Error('Insufficient permissions to move destinations');
     }
 
-    await moveDestinationToDay(destinationId, newDay);
+    const newOrderIndex = await getNextOrderIndex(destinationData.tripId, newDay);
+    await moveDestinationToDay(destinationId, newDay, newOrderIndex);
     
     // Log activity
     await logTripActivity(


### PR DESCRIPTION
## Summary
- pass correct arguments when reordering destinations so the underlying service knows trip/day and IDs
- calculate next order index when moving a destination to another day

## Testing
- `npm run type-check` *(fails: Property 'shareSettings' is missing...)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68966882c4e883248a6319e1a0998cb2